### PR TITLE
Simplify outfit removal command parsing

### DIFF
--- a/Source/Scripts/SFF_OutfitsManager.psc
+++ b/Source/Scripts/SFF_OutfitsManager.psc
@@ -71,7 +71,6 @@ EndFunction
 ; ======================================================================
 Event OnOutfitCommand(String eventName, String cmd, float numArg, Form sender)
     ; ---- declare locals first ----
-    String tag = ""
     Int    slotIdx = numArg as Int
     Actor  a = GetFollowerBySlot(slotIdx)
 
@@ -116,15 +115,14 @@ Event OnOutfitCommand(String eventName, String cmd, float numArg, Form sender)
 
     ; -------- text "remove:<tag>" parsing --------
     if cmd != ""
-        if StartsWith(cmd, "remove:")
-            tag = cmd.Substring(7) ; after "remove:"
-            if tag == "adventure"
-                RemoveSetForActor(a, KEY_ADVENTURE)
-            ElseIf tag == "town"
-                RemoveSetForActor(a, KEY_TOWN)
-            ElseIf tag == "home"
-                RemoveSetForActor(a, KEY_HOME)
-            endif
+        if cmd == "remove:" + KEY_ADVENTURE
+            RemoveSetForActor(a, KEY_ADVENTURE)
+            return
+        ElseIf cmd == "remove:" + KEY_TOWN
+            RemoveSetForActor(a, KEY_TOWN)
+            return
+        ElseIf cmd == "remove:" + KEY_HOME
+            RemoveSetForActor(a, KEY_HOME)
             return
         endif
     endif
@@ -577,7 +575,7 @@ Actor Function FindLoadedActorByName(String nm)
     return None
 EndFunction
 
-; Simple helper — default to Skyrim.esm; expand if you need plugin detection.
+; Simple helper Â— default to Skyrim.esm; expand if you need plugin detection.
 String Function GetPluginFor(Form f)
     return "Skyrim.esm"
 EndFunction
@@ -651,18 +649,4 @@ Function UnequipSetFromActor_JSON(Actor a, String base, Int count)
         endif
         i += 1
     endwhile
-EndFunction
-
-; ======================================================================
-; Small string helper
-; ======================================================================
-Bool Function StartsWith(String s, String prefix)
-    if s == "" || prefix == ""
-        return False
-    endif
-    Int pos = s.Find(prefix)
-    if pos == 0
-        return True
-    endif
-    return False
 EndFunction


### PR DESCRIPTION
## Summary
- replace substring-based remove command parsing with direct string matches for the known outfit keys
- drop the unused StartsWith helper that depended on unavailable Papyrus string functions

## Testing
- not run (Papyrus compiler not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68ce5b1f2cd883268f1e015d2e1aef53